### PR TITLE
Added IPython to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==1.3.6
 recommonmark==0.4.0
 nbsphinx
+ipython

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
     install_requires=[
         "setuptools",
         "recommonmark==0.4.0",
-        "nbsphinx"
+        "nbsphinx",
+        "ipython"
     ],
 
     packages=PKGS,


### PR DESCRIPTION
I was trying to build the sphinx theme example last week but it kept failing because `IPython`  package was not installed. This adds the package to requirements.txt and to setup.py